### PR TITLE
fix: Add missing parameters to codacyrc from specification CY-2866

### DIFF
--- a/src/addDefaultParameters.ts
+++ b/src/addDefaultParameters.ts
@@ -1,0 +1,44 @@
+import { Codacyrc, Parameter, Pattern, Specification } from "."
+
+export function addDefaultParameters(
+  codacyrc: Codacyrc,
+  specification?: Specification
+) {
+  const tools = codacyrc.tools ?? []
+  const specificationPatterns = specification ? specification.patterns : []
+
+  tools.map((tool) => {
+    const patterns = tool.patterns ?? []
+    patterns.map((pattern) =>
+      addDefaultParamentersToPattern(pattern, specificationPatterns)
+    )
+  })
+}
+
+function addDefaultParamentersToPattern(
+  pattern: Pattern,
+  specificationPatterns: Pattern[]
+) {
+  const specificationPattern = specificationPatterns.find(
+    (specPattern) => specPattern.patternId === pattern.patternId
+  )
+
+  specificationPattern
+    ? addMissingParameters(pattern.parameters, specificationPattern)
+    : pattern.parameters
+}
+
+function addMissingParameters(
+  parameters: Parameter[],
+  specificationPattern: Pattern
+) {
+  const finalParameters = specificationPattern.parameters.map(
+    (specParameter) => {
+      const overrideParameter = parameters.find(
+        (param) => param.name === specParameter.name
+      )
+      return overrideParameter ?? specParameter
+    }
+  )
+  parameters = finalParameters
+}

--- a/src/fileUtils.ts
+++ b/src/fileUtils.ts
@@ -3,6 +3,7 @@ import fs from "fs"
 import { promisify } from "util"
 
 import { Codacyrc } from "./model/codacyInput"
+import { Specification } from "./model/codacyInput"
 
 export const readFile = promisify(fs.readFile)
 export const writeFile = promisify(fs.writeFile)
@@ -18,5 +19,9 @@ export async function readJsonFile(file: string): Promise<string | undefined> {
 }
 
 export function parseCodacyrcFile(content: string): Codacyrc {
+  return JSON.parse(content)
+}
+
+export function parseSpecification(content: string): Specification {
   return JSON.parse(content)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   Parameter,
   ParameterValue,
   Pattern,
+  Specification,
   Tool
 } from "./model/codacyInput"
 import { DescriptionEntry, DescriptionParameter } from "./model/description"
@@ -20,6 +21,7 @@ import { FileError, Issue, ToolResult } from "./model/toolResult"
 import { run } from "./run"
 
 export {
+  Specification,
   Codacyrc,
   Tool,
   Pattern,

--- a/src/model/codacyInput.ts
+++ b/src/model/codacyInput.ts
@@ -12,7 +12,7 @@ export class Parameter {
 
 export class Pattern {
   readonly patternId: string
-  readonly parameters: Parameter[]
+  parameters: Parameter[]
 
   constructor(patternId: string, parameters: Parameter[] = []) {
     this.patternId = patternId
@@ -37,5 +37,13 @@ export class Codacyrc {
   constructor(files?: string[], tools?: Tool[]) {
     this.files = files
     this.tools = tools
+  }
+}
+
+export class Specification {
+  readonly patterns: Pattern[]
+
+  constructor(patterns: Pattern[]) {
+    this.patterns = patterns
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,13 +1,24 @@
+import { addDefaultParameters } from "./addDefaultParameters"
 import { Engine } from "./engine"
-import { parseCodacyrcFile, readJsonFile } from "./fileUtils"
+import {
+  parseCodacyrcFile,
+  parseSpecification,
+  readJsonFile
+} from "./fileUtils"
 import { parseTimeoutSeconds } from "./parseTimeoutSeconds"
 import { resultString } from "./resultString"
 
 async function runImpl(engine: Engine) {
-  const jsonFile = await readJsonFile("/.codacyrc")
+  const jsonSpecification = await readJsonFile("/docs/patterns.json")
+  const specificaiton = jsonSpecification
+    ? parseSpecification(jsonSpecification)
+    : undefined
 
-  const codacyrc = jsonFile ? parseCodacyrcFile(jsonFile) : undefined
+  const jsonCodacyrc = await readJsonFile("/.codacyrc")
+  const codacyrc = jsonCodacyrc ? parseCodacyrcFile(jsonCodacyrc) : undefined
 
+  // Adds default parameters to codacyrc when they are not present on the configuration
+  codacyrc ? addDefaultParameters(codacyrc, specificaiton) : undefined
   const toolResults = await engine(codacyrc)
 
   const lines = resultString(toolResults)


### PR DESCRIPTION
Adds the parameters from specification to the codacyrc. 
ESLint multi-test with this seed version is successful.

![image](https://user-images.githubusercontent.com/13315199/94192247-98372b00-fea6-11ea-9aff-eb5722ac3286.png)
